### PR TITLE
Add support for .ear files and a less naive short-circuit file checker.

### DIFF
--- a/codepulse/src/main/scala/bootstrap/liftweb/AppCleanup.scala
+++ b/codepulse/src/main/scala/bootstrap/liftweb/AppCleanup.scala
@@ -20,11 +20,23 @@
 package bootstrap.liftweb
 
 object AppCleanup {
-	private var hooks: List[() => Unit] = Nil
+	private var preShutdownHooks: List[() => Unit] = Nil
 
-	def add(cleanup: () => Unit) = hooks ::= cleanup
+	private var shutdownHooks: List[() => Unit] = Nil
+
+	def addPreShutdownHook(cleanup: () => Unit) = preShutdownHooks ::= cleanup
+
+	def addShutdownHook(cleanup: () => Unit) = shutdownHooks ::= cleanup
 
 	def runCleanup() = {
-		hooks.reverseIterator.foreach { _() }
+		try {
+			println("Running PreShutdownHooks")
+			preShutdownHooks.reverseIterator.foreach { _() }
+
+			println("Running ShutdownHooks")
+			shutdownHooks.reverseIterator.foreach { _() }
+		} catch {
+			case e: Throwable => e.printStackTrace
+		}
 	}
 }

--- a/codepulse/src/main/scala/com/secdec/codepulse/tracer/ProjectFileUploadHandler.scala
+++ b/codepulse/src/main/scala/com/secdec/codepulse/tracer/ProjectFileUploadHandler.scala
@@ -56,7 +56,7 @@ class ProjectFileUploadHandler(projectManager: ProjectManager) extends RestHelpe
 		case UploadPath("create") Post req => fallbackResponse {
 			for {
 				(inputFile, originalName, cleanup) <- getReqFile(req) ?~! "Creating a new project requires a file"
-				_ <- ProjectUploadData.checkForBinaryZip(inputFile) ?~ {
+				_ <- ProjectUploadData.checkForClassesInNestedArchive(inputFile) ?~ {
 					s"The file you picked doesn't have any compiled Java files."
 				}
 				name <- req.param("name") ?~ "You must specify a name"

--- a/codepulse/src/main/scala/com/secdec/codepulse/tracer/ProjectManager.scala
+++ b/codepulse/src/main/scala/com/secdec/codepulse/tracer/ProjectManager.scala
@@ -44,7 +44,11 @@ import reactive.Observing
 object ProjectManager {
 	lazy val defaultActorSystem = {
 		val sys = ActorSystem("ProjectManagerSystem")
-		AppCleanup.add { () => sys.shutdown() }
+		AppCleanup.addShutdownHook { () =>
+			sys.shutdown()
+			sys.awaitTermination()
+			println("Shutdown ProjectManager's ActorSystem")
+		}
 		sys
 	}
 }
@@ -196,6 +200,9 @@ class ProjectManager(val actorSystem: ActorSystem) extends Observing {
 	}
 
 	// Also make sure any dirty projects are saved when exiting
-	AppCleanup.add { () => flushProjects }
+	AppCleanup.addPreShutdownHook { () =>
+		flushProjects
+		println("Flushed ProjectManager projects")
+	}
 
 }

--- a/codepulse/src/main/scala/com/secdec/codepulse/tracer/ProjectUploadData.scala
+++ b/codepulse/src/main/scala/com/secdec/codepulse/tracer/ProjectUploadData.scala
@@ -69,6 +69,19 @@ object ProjectUploadData {
 		}
 	}
 
+	def checkForClassesInNestedArchive(file: File): Boolean = {
+		ZipEntryChecker.findFirstEntry(file) { (filename, entry, contents) =>
+			if (!entry.isDirectory) {
+				FilenameUtils.getExtension(entry.getName) match {
+					case "class" => true
+					case _ => false
+				}
+			} else {
+				false
+			}
+		}
+	}
+
 	/** A preliminary check on a File to see if it looks like an
 	  * exported .pulse file.
 	  */

--- a/codepulse/src/main/scala/com/secdec/codepulse/tracer/ProjectUploadData.scala
+++ b/codepulse/src/main/scala/com/secdec/codepulse/tracer/ProjectUploadData.scala
@@ -71,14 +71,7 @@ object ProjectUploadData {
 
 	def checkForClassesInNestedArchive(file: File): Boolean = {
 		ZipEntryChecker.findFirstEntry(file) { (filename, entry, contents) =>
-			if (!entry.isDirectory) {
-				FilenameUtils.getExtension(entry.getName) match {
-					case "class" => true
-					case _ => false
-				}
-			} else {
-				false
-			}
+			!entry.isDirectory && FilenameUtils.getExtension(entry.getName) == "class"
 		}
 	}
 

--- a/codepulse/src/main/scala/com/secdec/codepulse/tracer/TraceServer.scala
+++ b/codepulse/src/main/scala/com/secdec/codepulse/tracer/TraceServer.scala
@@ -36,7 +36,7 @@ object TraceServer {
 	private implicit lazy val socketServer = {
 		val ss = SocketServer.default(com.secdec.codepulse.userSettings.tracePort)
 		ss.start()
-		AppCleanup.add { () =>
+		AppCleanup.addPreShutdownHook { () =>
 			ss.shutdown
 			println("Shutdown TracerServer's socketServer")
 		}


### PR DESCRIPTION
This support allows .ear files to be seen as zip files (since they are typically), and expands the quick check for java class files to search in nested archives instead of only the top-most.

Fixed (via workaround) a cleanup issue that only exhibits in development workflows. This creates cleanup phases of preshutdown and shutdown. This still needs to be managed carefully. A better solution would define strict dependency (or have better error checking in the callbacks).